### PR TITLE
Fixed #4

### DIFF
--- a/SiUtil.hpp
+++ b/SiUtil.hpp
@@ -1,0 +1,38 @@
+/**
+ * @file SiUtil.hpp
+ * @author paul
+ * @date 17.07.20
+ * Implementation of utilities for SI
+ */
+#ifndef SI_SIUTIL_HPP
+#define SI_SIUTIL_HPP
+
+#if __cpp_conditional_explicit
+    #define EXPLICIT(expr) explicit(expr)
+#else
+    #define EXPLICIT(expr) explicit
+#endif
+
+namespace si { namespace util {
+    template <typename T, bool trivialCopyable>
+    struct CondCRefImpl {
+        using type = T;
+    };
+
+    template <typename T>
+    struct CondCRefImpl<T, false> {
+        using type = const T&;
+    };
+
+    /**
+     * Conditional const reference:
+     * Returns T if sizeof(SIZE_T) is less than the word size of your system, else returns const T&
+     * @tparam T the type to return
+     * @tparam SIZE_T the type used for checking, is T by default, in some cases it is necessary to specify a different
+     * type here.
+     */
+    template <typename T, typename SIZE_T = T>
+    using CondCRef = CondCRefImpl<typename std::remove_reference<T>::type, sizeof(SIZE_T) <= sizeof(std::size_t)>::type;
+}}
+
+#endif

--- a/SiUtil.hpp
+++ b/SiUtil.hpp
@@ -32,7 +32,7 @@ namespace si { namespace util {
      * type here.
      */
     template <typename T, typename SIZE_T = T>
-    using CondCRef = CondCRefImpl<typename std::remove_reference<T>::type, sizeof(SIZE_T) <= sizeof(std::size_t)>::type;
+    using CondCRef = typename CondCRefImpl<typename std::remove_reference<T>::type, sizeof(SIZE_T) <= sizeof(std::size_t)>::type;
 }}
 
 #endif


### PR DESCRIPTION
Wenn der Typ größer als die Word-Größe ist, dann werden die Argumente meistens als `const&` übergeben, sonst by-value.

Für Argumente deren Typ erst durch Type deduction bestimmt werden ist das nicht der Fall, da z.B. bei

```c++
template<typename T>
void fun(util::CondCRef<T> t);

fun(1);
```

der Compiler effektiv die Typgleichung `util::CondCRef<T> = int` auflösen müsste, was im Allgemeinen nicht eindeutig möglich sein muss. Daher scheitert da die Typ-Deduction. Ich habe mich deshalb entschieden die Objekte immer zu kopieren, sobald wir überall C++-20 Support haben können wir uns auch einige der Funktionen sparen.