### PR TITLE
Removed non portable and redundant cmake flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,3 @@ target_include_directories(${PROJECT_NAME} PUBLIC include)
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 20)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD_REQUIRED OFF)
-
-target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror -mtune=native -march=native)
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_compile_options(${PROJECT_NAME} PRIVATE -O0 -ggdb)
-else ()
-    target_compile_options(${PROJECT_NAME} PRIVATE -O3)
-endif ()


### PR DESCRIPTION
The manual selection of debug/release flags breaks portability with compilers that are not gcc/clang for x86 (i.e. `-march`, `-mtune` are not available with avr-gcc) . [As cmake sets the optimization/debug flags itself](https://stackoverflow.com/a/55275776) based on the target they are not required and can thus be removed without negative impact.